### PR TITLE
use closeablehttpclient instead of httpclient

### DIFF
--- a/src/main/java/nl/knaw/huygens/timbuctoo/remote/rs/download/ResourceSyncFileLoader.java
+++ b/src/main/java/nl/knaw/huygens/timbuctoo/remote/rs/download/ResourceSyncFileLoader.java
@@ -210,15 +210,16 @@ public class ResourceSyncFileLoader {
   }
 
   static class RemoteFileRetriever {
-    private final HttpClient httpClient;
+    private static final Logger LOG = getLogger(RemoteFileRetriever.class);
+    private final CloseableHttpClient httpClient;
     private final int timeout;
 
-    private RemoteFileRetriever(HttpClient httpClient) {
+    private RemoteFileRetriever(CloseableHttpClient httpClient) {
       this.httpClient = httpClient;
       this.timeout = 0;
     }
 
-    private RemoteFileRetriever(HttpClient httpClient, int timeout) {
+    private RemoteFileRetriever(CloseableHttpClient httpClient, int timeout) {
       this.httpClient = httpClient;
       this.timeout = timeout;
     }
@@ -235,7 +236,9 @@ public class ResourceSyncFileLoader {
         httpGet.addHeader("Authorization", authString);
       }
 
+      LOG.info("Calling " + url);
       HttpResponse httpResponse = httpClient.execute(httpGet);
+      LOG.info("Got response from " + url);
       if (httpResponse.getStatusLine().getStatusCode() == 200) {
         InputStream content = httpResponse.getEntity().getContent();
         if (content != null) {

--- a/src/main/java/nl/knaw/huygens/timbuctoo/remote/rs/download/ResourceSyncFileLoader.java
+++ b/src/main/java/nl/knaw/huygens/timbuctoo/remote/rs/download/ResourceSyncFileLoader.java
@@ -227,7 +227,7 @@ public class ResourceSyncFileLoader {
 
     public InputStream getFile(String url, String authString)
       throws CantRetrieveFileException, IOException {
-//      CloseableHttpClient httpClient = HttpClients.createDefault();
+      CloseableHttpClient httpClient = HttpClients.createDefault();
       HttpGet httpGet = new HttpGet(url);
 
       // Timeout time is set to 100 seconds to prevent socket timeout during changelist import

--- a/src/main/java/nl/knaw/huygens/timbuctoo/remote/rs/download/ResourceSyncFileLoader.java
+++ b/src/main/java/nl/knaw/huygens/timbuctoo/remote/rs/download/ResourceSyncFileLoader.java
@@ -11,6 +11,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
@@ -226,6 +227,7 @@ public class ResourceSyncFileLoader {
 
     public InputStream getFile(String url, String authString)
       throws CantRetrieveFileException, IOException {
+//      CloseableHttpClient httpClient = HttpClients.createDefault();
       HttpGet httpGet = new HttpGet(url);
 
       // Timeout time is set to 100 seconds to prevent socket timeout during changelist import

--- a/src/main/java/nl/knaw/huygens/timbuctoo/remote/rs/download/ResourceSyncImport.java
+++ b/src/main/java/nl/knaw/huygens/timbuctoo/remote/rs/download/ResourceSyncImport.java
@@ -38,16 +38,22 @@ public class ResourceSyncImport {
 
     Iterator<RemoteFile> files = filesToImport.iterator();
 
-    LOG.info("Found files '{}'", files.hasNext());
+    // Get total number of files found
+    int numOfFiles = filesToImport.size();
+    LOG.info("Found '{}' files to be processed", numOfFiles);
 
     if (!files.hasNext()) {
       LOG.error("No supported files available for import.");
       return;
     }
 
+    int fileCounter = 0;
     try {
       while (files.hasNext()) {
+        fileCounter++;
         RemoteFile file = files.next();
+        LOG.info("Processing file {} out of {}, location: {}  ", fileCounter, numOfFiles, file.getUrl());
+
         Future<?> fileFuture = withFile.withFile(
             file.getData().get(), file.getUrl(), file.getMimeType(), file.getMetadata().getDateTime());
 


### PR DESCRIPTION
There was an issue during fetching diff files. Somehow, HttpClient is being used and got stuck after 1 or 2 iterations. Replace it with CloseableHttpClient solves the issue. 
And a logger is added to the FileLoader. 
There are 2 PR created by bot, should probably review and merge before this one. One of the PR is labeled as high risk. 

After that we can test this PR with the newer package of jackson and other new packages, then merge this. 

Currently, we have an image label as both test (registry.diginfra.net/tsd/kabara:test) and 3.0.1 (registry.diginfra.net/tsd/kabara:3.0.1). It is the image for the running container on k8s